### PR TITLE
Release 1.0.5

### DIFF
--- a/FFmpegAvalonia/AppSettingsX/AppSettings.cs
+++ b/FFmpegAvalonia/AppSettingsX/AppSettings.cs
@@ -107,19 +107,21 @@ namespace FFmpegAvalonia.AppSettingsX
             PropertyInfo[] properties = typeof(Settings).GetProperties();
             foreach (PropertyInfo property in properties)
             {
-                object value;
                 if (doc.Root.Element(property.Name) != null)
                 {
                     bool? boolean = doc.Root.Element(property.Name).Value.TryParseToBool(out string str);
-                    if (boolean is null)
+                    if (boolean != null)
                     {
-                        value = str;
+                        property.SetValue(Settings, boolean);
+                        continue;
                     }
-                    else
+                    bool isInt32 = Int32.TryParse(str, out int num);
+                    if (isInt32)
                     {
-                        value = boolean;
+                        property.SetValue(Settings, num);
+                        continue;
                     }
-                    property.SetValue(Settings, value);
+                    property.SetValue(Settings, str);
                 }
             }
         }

--- a/FFmpegAvalonia/AppSettingsX/Settings.cs
+++ b/FFmpegAvalonia/AppSettingsX/Settings.cs
@@ -7,4 +7,5 @@ internal class Settings : PropertyReflection
     public string UpdateTarget { get; set; } = "release";
     public bool CheckUpdateOnStart { get; set; } = true;
     public bool AutoOverwriteCheck { get; set; }
+    public int SetStreamReadersFF { get; set; } = 0;
 }

--- a/FFmpegAvalonia/AppSettingsX/Settings.cs
+++ b/FFmpegAvalonia/AppSettingsX/Settings.cs
@@ -7,5 +7,5 @@ internal class Settings : PropertyReflection
     public string UpdateTarget { get; set; } = "release";
     public bool CheckUpdateOnStart { get; set; } = true;
     public bool AutoOverwriteCheck { get; set; }
-    public int SetStreamReadersFF { get; set; } = 0;
+    public bool DetachFFmpegProcess { get; set; } = false;
 }

--- a/FFmpegAvalonia/Extensions.cs
+++ b/FFmpegAvalonia/Extensions.cs
@@ -143,8 +143,6 @@ namespace ExtensionMethods
             {
                 "true" => true,
                 "false" => false,
-                "1" => true,
-                "0" => false,
                 _ => null,
             };
         }

--- a/FFmpegAvalonia/Extensions.cs
+++ b/FFmpegAvalonia/Extensions.cs
@@ -8,12 +8,12 @@ namespace ExtensionMethods
     {
         public static bool EndsWith(this StringBuilder haystack, string needle)
         {
-            var needleLength = needle.Length - 1;
-            var haystackLength = haystack.Length - 1;
-            if (haystackLength == 0)
+            if (haystack.Length == 0 || needle.Length == 0 || needle.Length > haystack.Length)
             {
                 return false;
             }
+            var needleLength = needle.Length - 1;
+            var haystackLength = haystack.Length - 1;
             for (int i = 0; i <= needleLength; i++)
             {
                 if (haystack[haystackLength - i] != needle[needleLength - i])
@@ -25,12 +25,12 @@ namespace ExtensionMethods
         }
         private static bool ContainsOrdinal(this StringBuilder haystack, string needle)
         {
-            int needleIndexLength = needle.Length - 1;
-            int haystackIndexLength = haystack.Length - 1;
             if (haystack.Length == 0 || needle.Length == 0 || needle.Length > haystack.Length)
             {
                 return false;
             }
+            int needleIndexLength = needle.Length - 1;
+            int haystackIndexLength = haystack.Length - 1;
             for (int i = 0; i <= haystackIndexLength && haystack.Length - i >= needleIndexLength; i++)
             {
                 if (haystack[i] == needle[0])
@@ -59,12 +59,12 @@ namespace ExtensionMethods
         }
         private static bool ContainsOrdinalIgnoreCase(this StringBuilder haystack, string needle)
         {
-            int needleIndexLength = needle.Length - 1;
-            int haystackIndexLength = haystack.Length - 1;
             if (haystack.Length == 0 || needle.Length == 0 || needle.Length > haystack.Length)
             {
                 return false;
             }
+            int needleIndexLength = needle.Length - 1;
+            int haystackIndexLength = haystack.Length - 1;
             for (int i = 0; i <= haystackIndexLength && haystack.Length - i >= needleIndexLength; i++)
             {
                 if (char.ToLower(haystack[i]) == needle[0])
@@ -115,15 +115,11 @@ namespace ExtensionMethods
         }
         public static void TrimEnd(this StringBuilder sb, string str)
         {
-            var strIndexLength = str.Length - 1;
-            var sbIndexLength = sb.Length - 1;
-            sb.Remove(sbIndexLength - strIndexLength, str.Length);
+            sb.Remove(sb.Length - str.Length, str.Length);
         }
         public static string ToStringTrimEnd(this StringBuilder sb, string trimEnd)
         {
-            var strIndexLength = trimEnd.Length - 1;
-            var sbIndexLength = sb.Length - 1;
-            return sb.ToString(0, sbIndexLength - strIndexLength);
+            return sb.ToString(0, sb.Length - trimEnd.Length);
         }
         public static bool ParseToBool(this string str)
         {
@@ -161,12 +157,7 @@ namespace ExtensionMethods
         }
         public static string Combine(this string[] stringArray)
         {
-            StringBuilder sb = new();
-            foreach (string str in stringArray)
-            {
-                sb.Append(str);
-            }
-            return sb.ToString();
+            return String.Join("", stringArray);
         }
         public static void Rename(this FileInfo file, string newName)
         {

--- a/FFmpegAvalonia/FFmpegAvalonia.csproj
+++ b/FFmpegAvalonia/FFmpegAvalonia.csproj
@@ -7,7 +7,7 @@
     <TrimMode>copyused</TrimMode>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
 	<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-	<AssemblyVersion>1.0.4.1</AssemblyVersion>
+	<AssemblyVersion>1.0.4.2</AssemblyVersion>
 	<ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/FFmpegAvalonia/FFmpegAvalonia.csproj
+++ b/FFmpegAvalonia/FFmpegAvalonia.csproj
@@ -7,7 +7,7 @@
     <TrimMode>copyused</TrimMode>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
 	<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-	<AssemblyVersion>1.0.4.2</AssemblyVersion>
+	<AssemblyVersion>1.0.5.0</AssemblyVersion>
 	<ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/FFmpegAvalonia/FFmpegAvalonia.csproj
+++ b/FFmpegAvalonia/FFmpegAvalonia.csproj
@@ -7,7 +7,7 @@
     <TrimMode>copyused</TrimMode>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
 	<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-	<AssemblyVersion>1.0.4.0</AssemblyVersion>
+	<AssemblyVersion>1.0.4.1</AssemblyVersion>
 	<ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/FFmpegAvalonia/PropertyReflection.cs
+++ b/FFmpegAvalonia/PropertyReflection.cs
@@ -1,22 +1,17 @@
-﻿namespace FFmpegAvalonia
+﻿namespace FFmpegAvalonia;
+
+public class PropertyReflection
 {
-    public class PropertyReflection
+    public string GetPropVal(string propertyName)
     {
-        public string GetPropVal(string propertyName)
+        object? val = this.GetType().GetProperty(propertyName).GetValue(this);
+        if (val == null)
         {
-            object? val = this.GetType().GetProperty(propertyName).GetValue(this);
-            if (val is bool bVal)
-            {
-                return bVal.ToString();
-            }
-            else if (val is null)
-            {
-                return "null";
-            }
-            else
-            {
-                return (string)val;
-            }
+            return "null";
+        }
+        else
+        {
+            return val.ToString() == null ? "null" : val.ToString()!;
         }
     }
 }

--- a/FFmpegAvalonia/TaskTypes/FFmpeg.cs
+++ b/FFmpegAvalonia/TaskTypes/FFmpeg.cs
@@ -21,33 +21,33 @@ namespace FFmpegAvalonia.TaskTypes
 {
     public class FFmpeg
     {
-        private FFmpegProcess _FFProcess;
-        private readonly string _FFmpegPath;
-        private readonly ConcurrentDictionary<string, int> _FilesDict;
-        private int _LastFrame;
-        private long _CancelQ = 0;
-        public bool CancelQ
+        private FFmpegProcess _ffProcess;
+        private readonly string _ffMpegPath;
+        private readonly ConcurrentDictionary<string, int> _filesDict;
+        private int _lastFrame;
+        private long _queueCanceled = 0;
+        public bool QueueCanceled
         {
-            get => Interlocked.Read(ref _CancelQ) == 1;
-            set => Interlocked.Exchange(ref _CancelQ, Convert.ToInt64(value));
+            get => Interlocked.Read(ref _queueCanceled) == 1;
+            private set => Interlocked.Exchange(ref _queueCanceled, Convert.ToInt64(value));
         }
-        private int _TotalPrevFrameProgress;
-        private int _TotalDirFrames;
-        private double _EndTime;
-        private IProgress<double>? _UIProgress;
-        private readonly object _DisposeLock = new();
-        private string _LastStdErrLine = String.Empty;
-        private MainWindowViewModel? _ViewModel;
-        private bool _SkipFile;
+        private int _totalPrevFrameProgress;
+        private int _totalDirFrames;
+        private double _endTime;
+        private IProgress<double>? _uIProgress;
+        private readonly object _disposeLock = new();
+        private string _lastStdErrLine = String.Empty;
+        private MainWindowViewModel? _viewModel;
+        private bool _skipFile;
         public FFmpeg(string ffmpegdir)
         {
-            _FFmpegPath = ffmpegdir;
-            _FFProcess = new FFmpegProcess(_FFmpegPath)
+            _ffMpegPath = ffmpegdir;
+            _ffProcess = new FFmpegProcess(_ffMpegPath)
             {
                 StartInfo = DefaultStartInfo(),
                 EnableRaisingEvents = true,
             };
-            _FilesDict = new ConcurrentDictionary<string, int>();
+            _filesDict = new ConcurrentDictionary<string, int>();
         }
         private static ProcessStartInfo DefaultStartInfo()
         {
@@ -60,59 +60,11 @@ namespace FFmpegAvalonia.TaskTypes
                 RedirectStandardError = true,
             };
         }
-        private void NewFFProcess(int redirect = 0)
+        private void NewFFProcess(bool detachProcess = false)
         {
-            if (redirect == 0)
+            if (detachProcess)
             {
-                _FFProcess = new FFmpegProcess(_FFmpegPath)
-                {
-                    StartInfo = DefaultStartInfo(),
-                    EnableRaisingEvents = true
-                };
-            }
-            else if (redirect == 1)
-            {
-                _FFProcess = new FFmpegProcess(_FFmpegPath)
-                {
-                    StartInfo = new() { CreateNoWindow = true, RedirectStandardInput = true, RedirectStandardOutput = true },
-                    EnableRaisingEvents = true
-                };
-            }
-            else if (redirect == 2)
-            {
-                _FFProcess = new FFmpegProcess(_FFmpegPath)
-                {
-                    StartInfo = new() { CreateNoWindow = true, RedirectStandardInput = true, RedirectStandardError = true },
-                    EnableRaisingEvents = true
-                };
-            }
-            else if (redirect == 3)
-            {
-                _FFProcess = new FFmpegProcess(_FFmpegPath)
-                {
-                    StartInfo = new() { RedirectStandardInput = true, RedirectStandardOutput = true },
-                    EnableRaisingEvents = true
-                };
-            }
-            else if (redirect == 4)
-            {
-                _FFProcess = new FFmpegProcess(_FFmpegPath)
-                {
-                    StartInfo = new() { RedirectStandardInput = true, RedirectStandardError = true },
-                    EnableRaisingEvents = true
-                };
-            }
-            else if (redirect == 5)
-            {
-                _FFProcess = new FFmpegProcess(_FFmpegPath)
-                {
-                    StartInfo = new() { CreateNoWindow = true },
-                    EnableRaisingEvents = true
-                };
-            }
-            else if (redirect == 6)
-            {
-                _FFProcess = new FFmpegProcess(_FFmpegPath)
+                _ffProcess = new FFmpegProcess(_ffMpegPath)
                 {
                     StartInfo = new(),
                     EnableRaisingEvents = true
@@ -120,7 +72,7 @@ namespace FFmpegAvalonia.TaskTypes
             }
             else
             {
-                _FFProcess = new FFmpegProcess(_FFmpegPath)
+                _ffProcess = new FFmpegProcess(_ffMpegPath)
                 {
                     StartInfo = DefaultStartInfo(),
                     EnableRaisingEvents = true
@@ -154,30 +106,30 @@ namespace FFmpegAvalonia.TaskTypes
 
                 if (!skipFrameRateCalc)
                 {
-                    _FFProcess.StartProbe($"-v 0 -of csv=p=0 -select_streams v:0 -show_entries stream=r_frame_rate \"{file.FullName}\"");
-                    string output = _FFProcess.StandardOutput.ReadToEnd().Trim();
+                    _ffProcess.StartProbe($"-v 0 -of csv=p=0 -select_streams v:0 -show_entries stream=r_frame_rate \"{file.FullName}\"");
+                    string output = _ffProcess.StandardOutput.ReadToEnd().Trim();
                     frameRate = decimal.Parse(output.Split(@"/")[0]) / decimal.Parse(output.Split(@"/")[1]);
 
                     Trace.TraceInformation("Framerate: " + frameRate);
-                    _FFProcess.WaitForExit();
+                    _ffProcess.WaitForExit();
 
-                    Trace.TraceInformation("Process Exit Code: " + _FFProcess.ExitCode);
+                    Trace.TraceInformation("Process Exit Code: " + _ffProcess.ExitCode);
                 }
 
-                _FFProcess.StartProbe($"-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"{file.FullName}\"");
-                decimal totalSeconds = decimal.Parse(_FFProcess.StandardOutput.ReadToEnd().Trim());
+                _ffProcess.StartProbe($"-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"{file.FullName}\"");
+                decimal totalSeconds = decimal.Parse(_ffProcess.StandardOutput.ReadToEnd().Trim());
 
                 Trace.TraceInformation("Total Seconds: " + totalSeconds);
-                _FFProcess.WaitForExit();
+                _ffProcess.WaitForExit();
 
-                Trace.TraceInformation("Process Exit Code: " + _FFProcess.ExitCode);
+                Trace.TraceInformation("Process Exit Code: " + _ffProcess.ExitCode);
 
                 decimal totalFrames = frameRate * totalSeconds;
-                _FilesDict.TryAdd(file.FullName, (int)totalFrames); //rounds down
-                _TotalDirFrames += (int)totalFrames;
+                _filesDict.TryAdd(file.FullName, (int)totalFrames); //rounds down
+                _totalDirFrames += (int)totalFrames;
                 sb.Append(" -- " + (int)totalFrames + " -- " + totalFrames + Environment.NewLine);
             }
-            _FFProcess.Dispose();
+            _ffProcess.Dispose();
             return sb.ToString();
         }
         public string GetFrameCountFromPackets(string dir, string searchPattern)
@@ -189,14 +141,14 @@ namespace FFmpegAvalonia.TaskTypes
             foreach (var file in files)
             {
                 sb.Append(file.FullName);
-                _FFProcess.StartInfo.Arguments = $"-v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets \"{file.FullName}\"";
-                _FFProcess.Start();
-                int totalFrames = int.Parse(_FFProcess.StandardOutput.ReadToEnd().Split("=")[1].Split("[")[0].Trim());
-                _FFProcess.WaitForExit();
-                _FilesDict.TryAdd(file.FullName, totalFrames);
+                _ffProcess.StartInfo.Arguments = $"-v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets \"{file.FullName}\"";
+                _ffProcess.Start();
+                int totalFrames = int.Parse(_ffProcess.StandardOutput.ReadToEnd().Split("=")[1].Split("[")[0].Trim());
+                _ffProcess.WaitForExit();
+                _filesDict.TryAdd(file.FullName, totalFrames);
                 sb.Append(" -- " + totalFrames + Environment.NewLine);
             }
-            _FFProcess.Dispose();
+            _ffProcess.Dispose();
             return sb.ToString();
         }
         public string GetFrameCount(string dir, string searchPattern)
@@ -208,159 +160,132 @@ namespace FFmpegAvalonia.TaskTypes
             foreach (var file in files)
             {
                 sb.Append(file.FullName);
-                _FFProcess.StartInfo.Arguments = $"-v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames \"{file.FullName}\"";
-                _FFProcess.Start();
-                int totalFrames = int.Parse(_FFProcess.StandardOutput.ReadToEnd().Split("=")[1].Split("[")[0].Trim());
-                _FFProcess.WaitForExit();
-                _FilesDict.TryAdd(file.FullName, totalFrames);
+                _ffProcess.StartInfo.Arguments = $"-v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames \"{file.FullName}\"";
+                _ffProcess.Start();
+                int totalFrames = int.Parse(_ffProcess.StandardOutput.ReadToEnd().Split("=")[1].Split("[")[0].Trim());
+                _ffProcess.WaitForExit();
+                _filesDict.TryAdd(file.FullName, totalFrames);
                 sb.Append(" -- " + totalFrames + Environment.NewLine);
             }
-            _FFProcess.Dispose();
+            _ffProcess.Dispose();
             return sb.ToString();
         }
-        public async Task<(int, string)> RunProfile(string args, string outputDir, string ext, IProgress<double> progress, MainWindowViewModel viewModel, CancellationToken ct, int setStreamReads = 0)
+        public async Task<(int, string)> RunProfile(string args, string outputDir, string ext, IProgress<double> progress, MainWindowViewModel viewModel, CancellationToken ct, bool detachProcess = false)
         {
             //Start out having progress bar show prog of entire dir
             //Progress would be current progress plus the sum of the files already done
-            if (setStreamReads == 0)
-                Trace.TraceInformation("Handling both standard output and standard error");
-            else if (setStreamReads == 1)
-                Trace.TraceInformation("Handling standard output only");
-            else if (setStreamReads == 2)
-                Trace.TraceInformation("Handling standard error only");
-            else if (setStreamReads == 3)
-                Trace.TraceInformation("Handling standard output only with window");
-            else if (setStreamReads == 4)
-                Trace.TraceInformation("Handling standard error only with window");
-            else if (setStreamReads == 5)
-                Trace.TraceInformation("Handling neither standard output nor standard error");
-            else if (setStreamReads == 6)
-                Trace.TraceInformation("Handling neither standard output nor standard error with window");
-            else if (setStreamReads == 7)
-                Trace.TraceInformation("Handling both standard output and standard error lbl");
-            else
-                return (-7, "SetStreamReadersFF value in settings can only be set a value in the range of 0-6");
-            _ViewModel = viewModel;
-            _UIProgress = progress;
+            _viewModel = viewModel;
+            _uIProgress = progress;
             Trace.TraceInformation($"Starting transcode to {outputDir}");
-            foreach (var filePath in _FilesDict.Keys)
+            foreach (var filePath in _filesDict.Keys)
             {
-                NewFFProcess(setStreamReads);
-                if (setStreamReads == 0 || setStreamReads == 1 || setStreamReads == 3)
+                if (detachProcess)
+                    Trace.TraceInformation("Creating detached ffmpeg process");
+                else
+                    Trace.TraceInformation("Creating attached ffmpeg process");
+                NewFFProcess(detachProcess);
+                if (!detachProcess)
                 {
-                    _FFProcess.OutputDataReceived += new DataReceivedEventHandler(StdOutHandler);
+                    _ffProcess.OutputDataReceived += new DataReceivedEventHandler(StdOutHandler);
                 }
-                if (setStreamReads == 7)
+                if (ct.IsCancellationRequested)
                 {
-                    if (File.Exists(filePath))
+                    if (detachProcess)
                     {
-                        await Dispatcher.UIThread.InvokeAsync(async () =>
-                        {
-                            var msgBox = AvaloniaMessageBox.MessageBox.GetMessageBox(new AvaloniaMessageBox.MessageBoxParams
-                            {
-                                Buttons = AvaloniaMessageBox.MessageBoxButtons.YesNo,
-                                Title = "File already exists",
-                                Message = filePath + " already exists would you like to overwrite?"
-                            });
-                            var app = (IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!;
-                            var result = await msgBox.ShowDialog(app.MainWindow);
-                            if (result == AvaloniaMessageBox.MessageBoxResult.Yes)
-                            {
-                                await _FFProcess.StandardInput.WriteLineAsync("y");
-                            }
-                            else
-                            {
-                                _SkipFile = true;
-                                await _FFProcess.StandardInput.WriteLineAsync("n");
-                            }
-                        }, DispatcherPriority.MaxValue);
+                        _ffProcess.Kill();
+                        await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
                     }
-                    if (_SkipFile) { _SkipFile = false; goto SkipFile; }
-                    _FFProcess.OutputDataReceived += new DataReceivedEventHandler(StdOutHandler);
-                    _FFProcess.ErrorDataReceived += (object sendingProcess, DataReceivedEventArgs e) => { if (e.Data != null) Trace.TraceInformation("STDERR**--" + e.Data); };
-                }
-                if (CancelQ)
-                {
-                    if (setStreamReads == 5 || setStreamReads == 6)
-                        _FFProcess.Kill();
-                    _FFProcess.Dispose();
-                    //CancelQ = false;
+                    _ffProcess.Dispose();
                     Trace.TraceInformation($"Canceled on {filePath}");
                     return (-1, filePath);
                 }
-                _FFProcess.StartMpeg($"-i \"{filePath}\" -progress pipe:1 {args} \"{Path.Combine(outputDir, Path.GetFileNameWithoutExtension(filePath) + ext)}\"");
-                if (setStreamReads == 0)
-                {
-                    _FFProcess.BeginOutputReadLine();
-                    await ReadStdErr();
-                }
-                else if (setStreamReads == 1 || setStreamReads == 3)
-                {
-                    _FFProcess.BeginOutputReadLine();
-                    try
-                    {
-                        await _FFProcess.WaitForExitAsync(ct);
-                    }
-                    catch (TaskCanceledException ex)
-                    {
-                        Debug.WriteLine(ex.ToString());
-                        await _FFProcess.WaitForExitAsync();
-                        //return (-1, filePath);
-                    }
-                }
-                else if (setStreamReads == 2 || setStreamReads == 4)
-                {
-                    await ReadStdErr();
-                }
-                else if (setStreamReads == 7)
-                {
-                    _FFProcess.BeginOutputReadLine();
-                    _FFProcess.BeginErrorReadLine();
-                    await _FFProcess.WaitForExitAsync();
-                }
-                else
+                _ffProcess.StartMpeg($"-i \"{filePath}\" -progress pipe:1 {args} \"{Path.Combine(outputDir, Path.GetFileNameWithoutExtension(filePath) + ext)}\"");
+                if (detachProcess)
                 {
                     try
                     {
-                        await _FFProcess.WaitForExitAsync(ct);
+                        await _ffProcess.WaitForExitAsync(ct);
                     }
                     catch (TaskCanceledException)
                     {
-                        _FFProcess.Kill();
-                        await _FFProcess.WaitForExitAsync();
-                        //return (-1, filePath);
+                        _ffProcess.Kill();
+                        await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
                     }
                 }
-                Trace.TraceInformation("Process Exit Code: " + _FFProcess.ExitCode);
-                if (CancelQ)
+                else
                 {
-                    _FFProcess.Dispose();
-                    //CancelQ = false;
+                    _ffProcess.BeginOutputReadLine();
+                    try
+                    {
+                        await ReadStdErr(ct); 
+                    }
+                    catch (TaskCanceledException taskCanceledExc)
+                    {
+                        QueueCanceled = true;
+                        await _ffProcess.StandardInput.WriteAsync('q');
+                        try
+                        {
+                            await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5)); 
+                        }
+                        catch (TimeoutException timeOutExc)
+                        {
+                            _ffProcess.Kill();
+                            await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                            _ffProcess.Dispose();
+                            Trace.TraceError(timeOutExc.ToString());
+                            return (-32, timeOutExc.ToString());
+                        }
+                        catch (Exception excInner)
+                        {
+                            _ffProcess.Kill();
+                            await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                            _ffProcess.Dispose();
+                            Trace.TraceError(excInner.ToString());
+                            return (-33, excInner.ToString());
+                        }
+                        Trace.TraceInformation(taskCanceledExc.ToString());
+                    }
+                    catch (Exception exc)
+                    {
+                        _ffProcess.Kill();
+                        _ffProcess.Dispose();
+                        Trace.TraceError(exc.ToString());
+                        return (-31, exc.ToString());
+                    }
+                }
+                Trace.TraceInformation("Process Exit Code: " + _ffProcess.ExitCode);
+                if (ct.IsCancellationRequested)
+                {
+                    if (detachProcess)
+                    {
+                        _ffProcess.Kill();
+                        await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                    }
+                    _ffProcess.Dispose();
                     Trace.TraceInformation($"Canceled on {filePath}");
                     return (-1, filePath);
                 }
-                if (_SkipFile)
+                if (_skipFile)
                 {
-                    _SkipFile = false;
+                    _skipFile = false;
                 }
-                else if (_FFProcess.ExitCode != 0)
+                else if (_ffProcess.ExitCode != 0)
                 {
-                    int exitCode = _FFProcess.ExitCode;
-                    _FFProcess.Dispose();
+                    int exitCode = _ffProcess.ExitCode;
+                    _ffProcess.Dispose();
                     Trace.TraceInformation($"Exited with code {exitCode} on {filePath}");
-                    return (exitCode, _LastStdErrLine);
+                    return (exitCode, _lastStdErrLine);
                 }
-                SkipFile:
-                _TotalPrevFrameProgress += _FilesDict[filePath];
-                lock (_DisposeLock)
+                _totalPrevFrameProgress += _filesDict[filePath];
+                lock (_disposeLock)
                 {
-                    _FFProcess.Dispose();
+                    _ffProcess.Dispose();
                 }
                 Trace.TraceInformation($"File transcode, \"{filePath}\", complete");
             }
-            if (setStreamReads != 0 && setStreamReads != 1 && setStreamReads != 3)
+            if (detachProcess)
             {
-                _UIProgress.Report(1);
+                _uIProgress.Report(1);
             }
             return (0, String.Empty);
         }
@@ -368,26 +293,11 @@ namespace FFmpegAvalonia.TaskTypes
         {
             throw new NotImplementedException();
         }
-        public async Task<(int, string)> TrimDir(ObservableCollection<TrimData> trimData, string sourceDir, string outputDir, IProgress<double> progress, ListViewData item, MainWindowViewModel viewModel, CancellationToken ct, int setStreamReads = 0)
+        public async Task<(int, string)> TrimDir(ObservableCollection<TrimData> trimData, string sourceDir, string outputDir, IProgress<double> progress, ListViewData item, MainWindowViewModel viewModel, CancellationToken ct, bool detachProcess = false)
         {
-            if (setStreamReads == 0)
-                Trace.TraceInformation("Handling both standard output and standard error");
-            else if (setStreamReads == 1)
-                Trace.TraceInformation("Handling standard output only");
-            else if (setStreamReads == 2)
-                Trace.TraceInformation("Handling standard error only");
-            else if (setStreamReads == 3)
-                Trace.TraceInformation("Handling standard output only with window");
-            else if (setStreamReads == 4)
-                Trace.TraceInformation("Handling standard error only with window");
-            else if (setStreamReads == 5)
-                Trace.TraceInformation("Handling neither standard output nor standard error");
-            else if (setStreamReads == 6)
-                Trace.TraceInformation("Handling neither standard output nor standard error with window");
-            else
-                return (-7, "SetStreamReadersFF value in settings can only be set a value in the range of 0-6");
-            _UIProgress = progress;
-            _ViewModel = viewModel;
+            _uIProgress = progress;
+            _viewModel = viewModel;
+            bool overwrite = outputDir == String.Empty || sourceDir == outputDir;
             var trimDataValidTimeCodes = trimData.Where(x => x.StartTime is not null && x.EndTime is not null);
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
@@ -395,221 +305,135 @@ namespace FFmpegAvalonia.TaskTypes
                 item.Label = $"{item.Name} ({item.Description.CurrentFileNumber}/{item.Description.FileCount})";
             });
             Trace.TraceInformation($"Starting trim to {outputDir} from {sourceDir}");
-            if (outputDir == string.Empty || sourceDir == outputDir)
+            foreach (TrimData data in trimDataValidTimeCodes)
             {
-                foreach (TrimData data in trimDataValidTimeCodes)
+                _endTime = (double)data.EndTime!.Value * 1000;
+                if (detachProcess)
+                    Trace.TraceInformation("Creating detached ffmpeg process");
+                else
+                    Trace.TraceInformation("Creating attached ffmpeg process");
+                NewFFProcess(detachProcess);
+                if (!detachProcess)
                 {
-                    _EndTime = (double)data.EndTime!.Value * 1000;
-                    NewFFProcess(setStreamReads);
-                    if (setStreamReads == 0 || setStreamReads == 1 || setStreamReads == 3)
-                    {
-                        _FFProcess.OutputDataReceived += new DataReceivedEventHandler(TrimStdOutHandler); 
-                    }
-                    if (CancelQ)
-                    {
-                        if (setStreamReads == 5 || setStreamReads == 6)
-                            _FFProcess.Kill();
-                        _FFProcess.Dispose();
-                        //CancelQ = false;
-                        Trace.TraceInformation($"Canceled on {data.FileInfo.FullName}");
-                        return (-1, data.FileInfo.FullName);
-                    }
-                    string newFile = Path.Combine(data.FileInfo.Directory.FullName, $"_{data.FileInfo.Name}");
-                    _FFProcess.StartMpeg($"-progress pipe:1 -ss {data.StartTime!.FormattedString} -to {data.EndTime.FormattedString} -i \"{data.FileInfo.FullName}\" -map 0 -codec copy \"{newFile}\"");
-                    if (setStreamReads == 0)
-                    {
-                        _FFProcess.BeginOutputReadLine();
-                        await ReadStdErr();
-                        //await _FFProcess.WaitForExitAsync();
-                    }
-                    else if (setStreamReads == 1 || setStreamReads == 3)
-                    {
-                        _FFProcess.BeginOutputReadLine();
-                        try
-                        {
-                            await _FFProcess.WaitForExitAsync(ct);
-                        }
-                        catch (TaskCanceledException)
-                        {
-                            await _FFProcess.WaitForExitAsync();
-                        }
-                    }
-                    else if (setStreamReads == 2 || setStreamReads == 4)
-                    {
-                        await ReadStdErr();
-                        //await _FFProcess.WaitForExitAsync();
-                    }
-                    else
-                    {
-                        try
-                        {
-                            await _FFProcess.WaitForExitAsync(ct);
-                        }
-                        catch (TaskCanceledException)
-                        {
-                            _FFProcess.Kill();
-                            await _FFProcess.WaitForExitAsync();
-                        }
-                    }
-                    Trace.TraceInformation("Process Exit Code: " + _FFProcess.ExitCode);
-                    if (CancelQ)
-                    {
-                        if (setStreamReads == 5 || setStreamReads == 6)
-                            _FFProcess.Kill();
-                        _FFProcess.Dispose();
-                        //CancelQ = false;
-                        Trace.TraceInformation($"Canceled on {data.FileInfo.FullName}");
-                        return (-1, data.FileInfo.FullName);
-                    }
-                    if (_SkipFile)
-                    {
-                        _SkipFile = false;
-                    }
-                    else if (_FFProcess.ExitCode == 0)
-                    {
-                        string rename = data.FileInfo.FullName;
-                        data.FileInfo.Delete();
-                        File.Move(newFile, rename);
-                    }
-                    else
-                    {
-                        int exitCode = _FFProcess.ExitCode;
-                        lock (_DisposeLock)
-                        {
-                            _FFProcess.Dispose();
-                        }
-                        Trace.TraceInformation($"Exited with code {exitCode} on {data.FileInfo.FullName}");
-                        return (exitCode, _LastStdErrLine);
-                    }
-                    lock (_DisposeLock)
-                    {
-                        _FFProcess.Dispose();
-                    }
-                    await Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        item.Label = $"{item.Name} ({++item.Description.CurrentFileNumber}/{item.Description.FileCount})";
-                    });
-                    Trace.TraceInformation($"File trim, \"{data.FileInfo.FullName}\", complete");
+                    _ffProcess.OutputDataReceived += new DataReceivedEventHandler(TrimStdOutHandler); 
                 }
-                return (0, String.Empty);
+                if (ct.IsCancellationRequested)
+                {
+                    if (detachProcess)
+                    {
+                        _ffProcess.Kill();
+                        await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                    }
+                    _ffProcess.Dispose();
+                    Trace.TraceInformation($"Canceled on {data.FileInfo.FullName}");
+                    return (-1, data.FileInfo.FullName);
+                }
+                string newFile;
+                if (overwrite)
+                {
+                    newFile = Path.Combine(data.FileInfo.Directory.FullName, $"_{data.FileInfo.Name}");
+                }
+                else
+                {
+                    newFile = Path.Combine(outputDir, data.FileInfo.Name);
+                }
+                _ffProcess.StartMpeg($"-progress pipe:1 -ss {data.StartTime!.FormattedString} -to {data.EndTime.FormattedString} -i \"{data.FileInfo.FullName}\" -map 0 -codec copy \"{newFile}\"");
+                if (detachProcess)
+                {
+                    try
+                    {
+                        await _ffProcess.WaitForExitAsync(ct);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        _ffProcess.Kill();
+                        await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                    }
+                }
+                else
+                {
+                    _ffProcess.BeginOutputReadLine();
+                    try
+                    {
+                        await ReadStdErr(ct); 
+                    }
+                    catch (TaskCanceledException taskCanceledExc)
+                    {
+                        QueueCanceled = true;
+                        await _ffProcess.StandardInput.WriteAsync('q');
+                        try
+                        {
+                            await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                        }
+                        catch (TimeoutException timeOutExc)
+                        {
+                            _ffProcess.Kill();
+                            await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                            _ffProcess.Dispose();
+                            Trace.TraceError(timeOutExc.ToString());
+                            return (-32, timeOutExc.ToString());
+                        }
+                        catch (Exception excInner)
+                        {
+                            _ffProcess.Kill();
+                            await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                            _ffProcess.Dispose();
+                            Trace.TraceError(excInner.ToString());
+                            return (-33, excInner.ToString());
+                        }
+                        Trace.TraceInformation(taskCanceledExc.ToString());
+                    }
+                    catch (Exception exc)
+                    {
+                        _ffProcess.Kill();
+                        _ffProcess.Dispose();
+                        Trace.TraceError(exc.ToString());
+                        return (-31, exc.ToString());
+                    }
+                }
+                Trace.TraceInformation("Process Exit Code: " + _ffProcess.ExitCode);
+                if (ct.IsCancellationRequested)
+                {
+                    if (detachProcess)
+                    {
+                        _ffProcess.Kill();
+                        await _ffProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                    }
+                    _ffProcess.Dispose();
+                    Trace.TraceInformation($"Canceled on {data.FileInfo.FullName}");
+                    return (-1, data.FileInfo.FullName);
+                }
+                if (_skipFile)
+                {
+                    _skipFile = false;
+                }
+                else if (_ffProcess.ExitCode == 0 && overwrite)
+                {
+                    string rename = data.FileInfo.FullName;
+                    data.FileInfo.Delete();
+                    File.Move(newFile, rename);
+                }
+                else if (_ffProcess.ExitCode != 0)
+                {
+                    int exitCode = _ffProcess.ExitCode;
+                    lock (_disposeLock)
+                    {
+                        _ffProcess.Dispose();
+                    }
+                    Trace.TraceInformation($"Exited with code {exitCode} on {data.FileInfo.FullName}");
+                    return (exitCode, _lastStdErrLine);
+                }
+                lock (_disposeLock)
+                {
+                    _ffProcess.Dispose();
+                }
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    item.Label = $"{item.Name} ({++item.Description.CurrentFileNumber}/{item.Description.FileCount})";
+                });
+                Trace.TraceInformation($"File trim, \"{data.FileInfo.FullName}\", complete");
             }
-            else
-            {
-                foreach (TrimData data in trimDataValidTimeCodes)
-                {
-                    _EndTime = (double)data.EndTime!.Value * 1000;
-                    NewFFProcess(setStreamReads);
-                    if (setStreamReads == 0 || setStreamReads == 1 || setStreamReads == 3)
-                    {
-                        _FFProcess.OutputDataReceived += new DataReceivedEventHandler(TrimStdOutHandler);
-                    }
-                    if (CancelQ)
-                    {
-                        if (setStreamReads == 5 || setStreamReads == 6)
-                            _FFProcess.Kill();
-                        _FFProcess.Dispose();
-                        //CancelQ = false;
-                        Trace.TraceInformation($"Canceled on {data.FileInfo.FullName}");
-                        return (-1, data.FileInfo.FullName);
-                    }
-                    string newFile = Path.Combine(outputDir, data.FileInfo.Name);
-                    _FFProcess.StartMpeg($"-progress pipe:1 -ss {data.StartTime!.FormattedString} -to {data.EndTime.FormattedString} -i \"{data.FileInfo.FullName}\" -map 0 -codec copy \"{newFile}\"");
-                    if (setStreamReads == 0)
-                    {
-                        _FFProcess.BeginOutputReadLine();
-                        await ReadStdErr();
-                        //await _FFProcess.WaitForExitAsync();
-                    }
-                    else if (setStreamReads == 1 || setStreamReads == 3)
-                    {
-                        _FFProcess.BeginOutputReadLine();
-                        try
-                        {
-                            await _FFProcess.WaitForExitAsync(ct);
-                        }
-                        catch (TaskCanceledException)
-                        {
-                            await _FFProcess.WaitForExitAsync();
-                        }
-                    }
-                    else if (setStreamReads == 2 || setStreamReads == 4)
-                    {
-                        await ReadStdErr();
-                        //await _FFProcess.WaitForExitAsync();
-                    }
-                    else
-                    {
-                        try
-                        {
-                            await _FFProcess.WaitForExitAsync(ct);
-                        }
-                        catch (TaskCanceledException)
-                        {
-                            _FFProcess.Kill();
-                            await _FFProcess.WaitForExitAsync();
-                        }
-                    }
-                    Trace.TraceInformation("Process Exit Code: " + _FFProcess.ExitCode);
-                    if (CancelQ)
-                    {
-                        if (setStreamReads == 5 || setStreamReads == 6)
-                            _FFProcess.Kill();
-                        _FFProcess.Dispose();
-                        //CancelQ = false;
-                        Trace.TraceInformation($"Canceled on {data.FileInfo.FullName}");
-                        return (-1, data.FileInfo.FullName);
-                    }
-                    if (_SkipFile)
-                    {
-                        _SkipFile = false;
-                    }
-                    else if (_FFProcess.ExitCode != 0)
-                    {
-                        int exitCode = _FFProcess.ExitCode;
-                        lock (_DisposeLock)
-                        {
-                            _FFProcess.Dispose();
-                        }
-                        Trace.TraceInformation($"Exited with code {exitCode} on {data.FileInfo.FullName}");
-                        return (exitCode, _LastStdErrLine);
-                    }
-                    lock (_DisposeLock)
-                    {
-                        _FFProcess.Dispose();
-                    }
-                    await Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        item.Label = $"{item.Name} ({++item.Description.CurrentFileNumber}/{item.Description.FileCount})";
-                    });
-                    Trace.TraceInformation($"File trim, \"{data.FileInfo.FullName}\", complete");
-                }
-                if (setStreamReads != 0 && setStreamReads != 1 && setStreamReads != 3)
-                {
-                    _UIProgress.Report(1);
-                }
-                return (0, String.Empty);
-            }
-        }
-        public void Stop()
-        {
-            Trace.TraceInformation($"CancelQ (acquire) = {CancelQ}");
-            lock (_DisposeLock)
-            {
-                try
-                {
-                    //_FFProcess.Refresh();
-                    if (!_FFProcess.HasExited)
-                    {
-                        CancelQ = true;
-                        _FFProcess.StandardInput.Write("q");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Trace.TraceError(ex.ToString());
-                }
-            }
-            Trace.TraceInformation($"CancelQ (release) = {CancelQ}");
+            return (0, String.Empty);
         }
         public static bool CheckFFmpegExecutable(string location)
         {
@@ -659,29 +483,29 @@ namespace FFmpegAvalonia.TaskTypes
                 return false;
             }
         }
-        private async Task ReadStdErr()
+        private async Task ReadStdErr(CancellationToken ct)
         {
-            var sr = _FFProcess.StandardError;
+            var sr = _ffProcess.StandardError;
             var sb = new StringBuilder();
             char[] buffer = new char[1];
-            while ((await sr.ReadAsync(buffer, 0, 1)) > 0)
+            while ((await sr.ReadAsync(buffer, 0, 1).WaitAsync(ct)) > 0)
             {
                 sb.Append(buffer[0]);
                 if (buffer[0] == '\n')
                 {
-                    _LastStdErrLine = sb.ToStringTrimEnd(Environment.NewLine);
+                    _lastStdErrLine = sb.ToStringTrimEnd(Environment.NewLine);
                     sb.Clear();
-                    Trace.TraceInformation(_LastStdErrLine);
+                    Trace.TraceInformation("STDERR**--" + _lastStdErrLine);
                 }
                 else if (buffer[0] == ']' && sb[^2] == 'N' && sb[^3] == '/' && sb[^4] == 'y' && sb[^5] == '[') //only N] should be necessary to search for but just in case we search for the whole thing
                 {
                     Trace.TraceInformation("Yes/No prompt found");
                     await sr.ReadAsync(buffer, 0, 1); //This should be space character ' '
                     Debug.WriteLine(buffer[0]);
-                    _LastStdErrLine = sb.ToString();
-                    if (_ViewModel!.AutoOverwriteCheck)
+                    _lastStdErrLine = sb.ToString();
+                    if (_viewModel!.AutoOverwriteCheck)
                     {
-                        await _FFProcess.StandardInput.WriteLineAsync("y");
+                        await _ffProcess.StandardInput.WriteLineAsync("y");
                     }
                     else
                     {
@@ -691,23 +515,23 @@ namespace FFmpegAvalonia.TaskTypes
                             {
                                 Buttons = AvaloniaMessageBox.MessageBoxButtons.YesNo,
                                 Title = "FFmpeg yes/no prompt",
-                                Message = _LastStdErrLine.Replace("[y/N]", "").Trim()
+                                Message = _lastStdErrLine.Replace("[y/N]", "").Trim()
                             });
                             var app = (IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!;
                             var result = await msgBox.ShowDialog(app.MainWindow);
                             if (result == AvaloniaMessageBox.MessageBoxResult.Yes)
                             {
-                                await _FFProcess.StandardInput.WriteLineAsync("y");
+                                await _ffProcess.StandardInput.WriteLineAsync("y");
                             }
                             else
                             {
-                                _SkipFile = true;
-                                await _FFProcess.StandardInput.WriteLineAsync("n");
+                                _skipFile = true;
+                                await _ffProcess.StandardInput.WriteLineAsync("n");
                             }
                         }, DispatcherPriority.MaxValue);
                     }
                     sb.Clear();
-                    Trace.TraceInformation(_LastStdErrLine);
+                    Trace.TraceInformation("STDERR**--" + _lastStdErrLine);
                 }
             }
         }
@@ -718,16 +542,16 @@ namespace FFmpegAvalonia.TaskTypes
                 Trace.TraceInformation("STDOUT**--" + e.Data);
                 if (e.Data.Contains("frame="))
                 {
-                    _LastFrame = int.Parse(e.Data.Split("=")[1].Trim());
-                    Trace.TraceInformation($"Progress: {_LastFrame} frames finished (file)");
-                    double progress = ((double)_LastFrame + _TotalPrevFrameProgress) / _TotalDirFrames;
+                    _lastFrame = int.Parse(e.Data.Split("=")[1].Trim());
+                    Trace.TraceInformation($"Progress: {_lastFrame} frames finished (file)");
+                    double progress = ((double)_lastFrame + _totalPrevFrameProgress) / _totalDirFrames;
                     Trace.TraceInformation($"Progress: {progress} percentage frames finished (directory)");
-                    _UIProgress!.Report(((double)_LastFrame + _TotalPrevFrameProgress) / _TotalDirFrames);
+                    _uIProgress!.Report(((double)_lastFrame + _totalPrevFrameProgress) / _totalDirFrames);
                 }
-                else if (e.Data.Contains("progress=end") && !CancelQ)
+                else if (e.Data.Contains("progress=end") && !QueueCanceled)
                 {
                     Trace.TraceInformation("File completed");
-                    _UIProgress!.Report(1);
+                    _uIProgress!.Report(1);
                 }
             }
         }
@@ -739,13 +563,13 @@ namespace FFmpegAvalonia.TaskTypes
                 if (e.Data.Contains("out_time="))
                 {
                     double currentTime = double.Parse(e.Data.Split("=")[1].Replace(":", "").Replace(".", ""));
-                    Trace.TraceInformation($"Progress: {currentTime} (current time) / {_EndTime} (end time)");
-                    _UIProgress!.Report(currentTime / _EndTime);
+                    Trace.TraceInformation($"Progress: {currentTime} (current time) / {_endTime} (end time)");
+                    _uIProgress!.Report(currentTime / _endTime);
                 }
-                else if (e.Data.Contains("progress=end") && !CancelQ)
+                else if (e.Data.Contains("progress=end") && !QueueCanceled)
                 {
                     Trace.TraceInformation("File completed");
-                    _UIProgress!.Report(1);
+                    _uIProgress!.Report(1);
                 }
             }
         }

--- a/FFmpegAvalonia/TaskTypes/FFmpeg.cs
+++ b/FFmpegAvalonia/TaskTypes/FFmpeg.cs
@@ -271,7 +271,7 @@ namespace FFmpegAvalonia.TaskTypes
                         int exitCode = _FFProcess.ExitCode;
                         lock (_DisposeLock)
                         {
-                        _FFProcess.Dispose();
+                            _FFProcess.Dispose();
                         }
                         Trace.TraceInformation($"Exited with code {exitCode} on {data.FileInfo.FullName}");
                         return (exitCode, _LastStdErrLine);
@@ -324,7 +324,7 @@ namespace FFmpegAvalonia.TaskTypes
                         int exitCode = _FFProcess.ExitCode;
                         lock (_DisposeLock)
                         {
-                            _FFProcess.Dispose(); 
+                            _FFProcess.Dispose();
                         }
                         Trace.TraceInformation($"Exited with code {exitCode} on {data.FileInfo.FullName}");
                         return (exitCode, _LastStdErrLine);
@@ -426,7 +426,7 @@ namespace FFmpegAvalonia.TaskTypes
                 if (sb.EndsWith(Environment.NewLine))
                 {
                     _LastStdErrLine = sb.ToStringTrimEnd(Environment.NewLine);
-                    sb = new StringBuilder();
+                    sb.Clear();
                     Trace.TraceInformation(_LastStdErrLine);
                 }
                 else if (sb.Contains("[y/N]", StringComparison.OrdinalIgnoreCase))
@@ -460,7 +460,7 @@ namespace FFmpegAvalonia.TaskTypes
                             }
                         }, DispatcherPriority.MaxValue);
                     }
-                    sb = new StringBuilder();
+                    sb.Clear();
                     Trace.TraceInformation(line);
                 }
             }

--- a/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
@@ -481,6 +481,9 @@ namespace FFmpegAvalonia.ViewModels
         }
         private void StopQueue()
         {
+            Trace.TraceInformation("Stopping queue");
+            Trace.TraceInformation("CurrentItemInProgress is null: " + (CurrentItemInProgress == null).ToString());
+            Trace.TraceInformation("CurrentItemInProgress Task: " + CurrentItemInProgress?.Description.Task.ToString());
             if (CurrentItemInProgress?.Description.Task == ItemTask.Transcode || CurrentItemInProgress?.Description.Task == ItemTask.Trim)
             {
                 if (FFmp != null)
@@ -489,6 +492,7 @@ namespace FFmpegAvalonia.ViewModels
                 }
                 else
                 {
+                    Trace.TraceInformation("FFmp seems to be null");
                     ShowMessageBox.Handle(new MessageBoxParams
                     {
                         Title = "Error",
@@ -505,6 +509,7 @@ namespace FFmpegAvalonia.ViewModels
                 }
                 else
                 {
+                    Trace.TraceInformation("Copier seems to be null");
                     ShowMessageBox.Handle(new MessageBoxParams
                     {
                         Title = "Error",
@@ -513,7 +518,10 @@ namespace FFmpegAvalonia.ViewModels
                     });
                 }
             }
-            else { }
+            else
+            {
+                Trace.TraceInformation("Using cancellation token");
+            }
         }
         private async Task Editor(string controlName)
         {

--- a/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
@@ -399,7 +399,9 @@ namespace FFmpegAvalonia.ViewModels
                         outputDir: item.Description.OutputDir,
                         ext: item.Description.Profile.OutputExtension,
                         progress: new Progress<double>(x => item.Progress = x),
-                        viewModel: this
+                        viewModel: this,
+                        ct: ct,
+                        setStreamReads: AppSettings.Settings.SetStreamReadersFF
                     );
                 }
                 else if (item.Description.Task == ItemTask.Copy)
@@ -424,7 +426,9 @@ namespace FFmpegAvalonia.ViewModels
                         trimData: item.Description.TrimData!,
                         progress: new Progress<double>(x => item.Progress = x),
                         item: item,
-                        viewModel: this
+                        viewModel: this,
+                        ct: ct,
+                        setStreamReads: AppSettings.Settings.SetStreamReadersFF
                     );
                 }
                 else if (item.Description.Task == ItemTask.UploadAWS)

--- a/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
@@ -584,7 +584,15 @@ namespace FFmpegAvalonia.ViewModels
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                assetIdentifier = "osx";
+                if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                {
+                    assetIdentifier = "osx-arm64";
+                }
+                else if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
+                {
+                    assetIdentifier = "osx-x64";
+                }
+                else throw new Exception("OS Platform not supported");
             }
             else throw new Exception("OS Platform not supported");
             Trace.TraceInformation($"Asset Identifier: {assetIdentifier}");

--- a/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
@@ -325,7 +325,26 @@ namespace FFmpegAvalonia.ViewModels
         }
         private async Task StartQueueAsync(CancellationToken ct)
         {
-            (int, string) response = await Task.Run(() => ProcessTaskItems(ct));
+            (int, string) response;
+            try
+            {
+                response = await Task.Run(() => ProcessTaskItems(ct));
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError($"An exception occurred in processing items task{Environment.NewLine}" +
+                    $"Exception = \"{ex}\"{Environment.NewLine}" +
+                    $"Task type = \"{CurrentItemInProgress?.Description.Task.ToString()}\"{Environment.NewLine}" +
+                    $"Cancel requested = \"{ct.IsCancellationRequested}\"");
+                await ShowMessageBox.Handle(new MessageBoxParams
+                {
+                    Title = "Exception",
+                    Message = ex.ToString(),
+                    Buttons = MessageBoxButtons.Ok,
+                    StartupLocation = WindowStartupLocation.CenterOwner
+                });
+                return;
+            }
             if (response.Item1 == 0 && !ct.IsCancellationRequested) //Success
             {
                 Trace.TraceInformation("Queue completed");

--- a/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
@@ -563,6 +563,10 @@ namespace FFmpegAvalonia.ViewModels
             {
                 assetIdentifier = "linux";
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                assetIdentifier = "osx";
+            }
             else throw new Exception("OS Platform not supported");
             Trace.TraceInformation($"Asset Identifier: {assetIdentifier}");
 

--- a/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/FFmpegAvalonia/ViewModels/MainWindowViewModel.cs
@@ -433,7 +433,8 @@ namespace FFmpegAvalonia.ViewModels
                     response = await Copier.CopyDirectory(
                         sourceDir: item.Description.SourceDir,
                         outputDir: item.Description.OutputDir,
-                        ext: '*' + item.Description.FileExt
+                        ext: '*' + item.Description.FileExt,
+                        ct: ct
                     );
                 }
                 else if (item.Description.Task == ItemTask.Trim)
@@ -520,23 +521,6 @@ namespace FFmpegAvalonia.ViewModels
                     {
                         Title = "Error",
                         Message = "There does not appear to be an FFmpeg instance running",
-                        Buttons = MessageBoxButtons.Ok
-                    });
-                }
-            }
-            else if (CurrentItemInProgress?.Description.Task == ItemTask.Copy)
-            {
-                if (Copier != null)
-                {
-                    Copier.Stop();
-                }
-                else
-                {
-                    Trace.TraceInformation("Copier seems to be null");
-                    ShowMessageBox.Handle(new MessageBoxParams
-                    {
-                        Title = "Error",
-                        Message = "There does not appear to be an copier instance running",
                         Buttons = MessageBoxButtons.Ok
                     });
                 }


### PR DESCRIPTION
## Features
+ Add support for OSX
+ More log information
+ Additional setting to detach ffmpeg process
   + When `DetachFFmpegProcess` is set to `true` ffmpeg will run and show up in its own terminal like normal
   + Note that this will mean progress does not update while ffmpeg is running
## BugFixes
+ Fixed choosing no on overwrite prompt
+ Fixed ffmpeg speed degrading to basically a stand still on certain video codecs